### PR TITLE
Quick fix for ref range tag showing in delete dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scripture-tsv",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": "https://github.com/unfoldingWord/scripture-tsv.git",
   "main": "./dist/main.es.js",
   "module": "./dist/main.cs.js",

--- a/src/libs/DeleteRow/components/DeleteRowDialog.tsx
+++ b/src/libs/DeleteRow/components/DeleteRowDialog.tsx
@@ -29,12 +29,14 @@ const DeleteRowDialog: React.FC<DeleteRowDialogProps> = ({
   currentRow,
   style = {},
 }) => {
-  const renderedRowValue = ([columnName, value]: [string, string]) => (
-    <DialogContentText key={columnName} sx={{ mb: 1 }}>
-      <strong>{columnName}: </strong>
-      <span>{value}</span>
-    </DialogContentText>
-  )
+  const renderedRowValue = ([columnName, value]: [string, string]) =>
+    // TODO: THIS IS A HACK... Implement dynamic column names
+    columnName !== '_referenceRange' ? (
+      <DialogContentText key={columnName} sx={{ mb: 1 }}>
+        <strong>{columnName}: </strong>
+        <span>{value}</span>
+      </DialogContentText>
+    ) : null
 
   const renderedTSVRowValuePairs = isValidTSVRow(currentRow)
     ? Object.entries(currentRow).map(renderedRowValue)


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] Fix for [QA Fail](https://app.zenhub.com/workspaces/gatewayedit-5fa302df5c4ec9001f1d5d54/issues/gh/unfoldingword/gateway-edit/593)
- [ ] Ref range tag no longer shows on the delete dialog

## Test Instructions

- [ ] Open [Deploy Preview](https://deploy-preview-634--gateway-edit.netlify.app/)
- [ ] Create a new translation note with a reference range (i.e 1:1-4 OR 2:3;3:4)
  - [ ] Once the new note is created and the app has navigated there, click on the delete button
  - [ ] Verify that the `_referenceRange` section of the dialog no longer shows
