### PR TITLE
Added validity of verse 'front' to TSVs structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scripture-tsv",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": "https://github.com/unfoldingWord/scripture-tsv.git",
   "main": "./dist/main.es.js",
   "module": "./dist/main.cs.js",

--- a/src/core/TsvTypes.d.ts
+++ b/src/core/TsvTypes.d.ts
@@ -26,7 +26,7 @@ export type ItemIndex = number
 /**
  * A string in the format 'chapter:verse'.
  * 'chapter' can be a number or the word 'front'
- * 'verse'' can be a number, the word 'intro', or a verse range (verseStart-verseEnd)
+ * 'verse'' can be a number, the word 'intro', the word 'front', or a verse range (verseStart-verseEnd)
  * Can be a reference range (i.e 1:2-3)
  * Can be multiple references (i.e 2:3;4:23)
  */

--- a/src/core/scriptureTsvValidation.test.ts
+++ b/src/core/scriptureTsvValidation.test.ts
@@ -40,6 +40,13 @@ describe('scriptureTsvValidation', () => {
       expect(isValidScriptureTSV(scriptureTSV)).toBe(true)
     })
 
+    it('should return true for special verse keys like "front"', () => {
+      const scriptureTSV: ScriptureTSV = {
+        3: { front: [{ Reference: '3:front', ID: 'a123' }] },
+      }
+      expect(isValidScriptureTSV(scriptureTSV)).toBe(true)
+    })
+
     it('should return true for valid ScriptureTSV objects', () => {
       const validScriptureTSV: ScriptureTSV = {
         1: {
@@ -108,6 +115,12 @@ describe('scriptureTsvValidation', () => {
         true
       )
       expect(isValidTSVRow({ Reference: '2:3;4:23', ID: 'c345' }, bookId)).toBe(
+        true
+      )
+    })
+
+    it('should return true if verse is front', () => {
+      expect(isValidTSVRow({ Reference: '3:front', ID: 'z123' }, bookId)).toBe(
         true
       )
     })

--- a/src/core/scriptureTsvValidation.ts
+++ b/src/core/scriptureTsvValidation.ts
@@ -36,7 +36,7 @@ export function isValidScriptureTSV(obj: any): obj is ScriptureTSV {
     // Check each verse in the chapter
     for (const verse in verses) {
       const verseNum = parseInt(verse, 10)
-      if (verse !== 'intro' && isNaN(verseNum)) {
+      if (verse !== 'intro' && verse !== 'front' && isNaN(verseNum)) {
         return false
       }
 
@@ -71,10 +71,14 @@ export function isValidTSVRow(
   }
 
   // Validate ReferenceString (format 'chapter:verse' or 'chapter:verseStart-verseEnd')
+  const shouldCheckInBook = (ref: string) =>
+    !!bookId && !ref.includes('front') && !ref.includes('intro')
+
   if (
     typeof row.Reference !== 'string' ||
     !parseReferenceToList(row.Reference).length ||
-    (!!bookId && !ReferenceUtils.isRefInBook(row.Reference, bookId))
+    (shouldCheckInBook(row.Reference) &&
+      !ReferenceUtils.isRefInBook(row.Reference, bookId))
   ) {
     return false
   }


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] Bump version of scripture-tsv to 1.0.3 for 'front' validity for verse
- [ ] Fix for [#636](https://github.com/unfoldingWord/gateway-edit/issues/636)

## Test Instructions

- [ ] Open [Deploy Preview](https://deploy-preview-639--gateway-edit.netlify.app/)
- [ ] Navigate to Psalms
  - [ ] Click on the Add button in translation notes
  - [ ] Verify that all rows generate as normal


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
