### PR TITLE
Add helper function to convert markdown to HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scripture-tsv",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "repository": "https://github.com/unfoldingWord/scripture-tsv.git",
   "main": "./dist/main.es.js",
   "module": "./dist/main.cs.js",
@@ -24,7 +24,9 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "dompurify": "^3.0.8",
     "lodash.clonedeep": "^4.5.0",
+    "marked": "^11.2.0",
     "tsv": "^0.2.0",
     "use-deep-compare-effect": "^1.8.1"
   },
@@ -59,6 +61,7 @@
     "@storybook/react": "^7.6.6",
     "@storybook/react-vite": "^7.6.6",
     "@storybook/test": "^7.6.6",
+    "@types/dompurify": "^3.0.5",
     "@types/jest": "^29.5.11",
     "@types/lodash.clonedeep": "^4.5.8",
     "@types/node": "^20.10.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,15 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  dompurify:
+    specifier: ^3.0.8
+    version: 3.0.8
   lodash.clonedeep:
     specifier: ^4.5.0
     version: 4.5.0
+  marked:
+    specifier: ^11.2.0
+    version: 11.2.0
   tsv:
     specifier: ^0.2.0
     version: 0.2.0
@@ -73,6 +79,9 @@ devDependencies:
   '@storybook/test':
     specifier: ^7.6.6
     version: 7.6.6(@types/jest@29.5.11)(vitest@1.1.0)
+  '@types/dompurify':
+    specifier: ^3.0.5
+    version: 3.0.5
   '@types/jest':
     specifier: ^29.5.11
     version: 29.5.11
@@ -4308,6 +4317,12 @@ packages:
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
     dev: true
 
+  /@types/dompurify@3.0.5:
+    resolution: {integrity: sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==}
+    dependencies:
+      '@types/trusted-types': 2.0.7
+    dev: true
+
   /@types/ejs@3.1.5:
     resolution: {integrity: sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==}
     dev: true
@@ -4516,6 +4531,10 @@ packages:
 
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+    dev: true
+
+  /@types/trusted-types@2.0.7:
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
     dev: true
 
   /@types/tsv@0.2.4:
@@ -5765,6 +5784,10 @@ packages:
       '@babel/runtime': 7.23.7
       csstype: 3.1.3
     dev: true
+
+  /dompurify@3.0.8:
+    resolution: {integrity: sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ==}
+    dev: false
 
   /dotenv-expand@10.0.0:
     resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
@@ -7697,6 +7720,12 @@ packages:
     dependencies:
       react: 18.2.0
     dev: true
+
+  /marked@11.2.0:
+    resolution: {integrity: sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==}
+    engines: {node: '>= 18'}
+    hasBin: true
+    dev: false
 
   /mdast-util-definitions@4.0.0:
     resolution: {integrity: sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,17 @@
 import React from 'react'
 import './App.css'
-import AddTsvRowSandbox from './libs/AddRow/AddTsvRowSandbox'
+import { markdownToHTML } from './core/markdownToHTML'
+
+const MARKDOWN =
+  '# 1 Timothy 1 General Notes\n\n## Structure and Formatting\n\n1. Letter opening (1:1–2)\n2. Paul urges Timothy to condemn false teachers (1:3–11)\n      * Paul commands Timothy to silence the false teachers (1:3–7)\n      * The purpose of the law (1:8–11)\n3. Paul thanks Jesus and praises God (1:12–17)\n4. Paul warns and encourages Timothy (1:18–20)\n\n## Special Concepts in This Chapter\n\n### The prophecies about Timothy\n\nIn [1:18](../01/18.md), Paul indicates that there were prophecies about Timothy. Paul implies that the prophecies are related to how Timothy will faithfully serve God by proclaiming the gospel. It is not clear when these prophecies were given. They may have been given before Timothy was born, when he was a child, when he became a believer, or when he was commissioned to serve with Paul. It is also not clear who gave these prophecies. When you translate this verse, it is best to refer to these prophecies with as few details as Paul gives.\n\n## Important Figures of Speech in This Chapter\n\n### Spiritual children\n\nIn [1:2](../01/02.md), Paul calls Timothy a “genuine child in the faith.” He means that Timothy is like a legitimate son to him in the context of their faith in Jesus. The phrase implies that Paul is a mentor to Timothy and that Timothy is a good student. When Paul again calls Timothy “child” in [1:18](../01/18.md), he means something very similar: Paul is Timothy’s mentor in the context of their faith in Jesus. Since the use of family language for fellow believers is an important metaphor in the New Testament, if possible preserve the metaphor or express the idea in simile form. See the notes on these verses for translation options. (See: [[rc://*/ta/man/translate/figs-metaphor]])\n\n### Fighting the good fight\n\nIn [1:18](../01/18.md), Paul exhorts Timothy to “fight the good fight.” He compares how Timothy must serve God by proclaiming the gospel to how soldiers fight in a war. He implies that Timothy will experience conflict, danger, and hardship and that he must obey God and Paul as a soldier obeys his commanders. Since Paul uses warfare language to refer to the Christian life in many verses, if possible preserve the metaphor or express the idea in simile form. See the notes on this verse for translation options. (See: [[rc://*/ta/man/translate/figs-metaphor]])\n\n### Shipwrecked regarding the faith\n\nIn [1:19](../01/19.md), Paul refers to people who “have shipwrecked regarding the faith.” As a ship breaks apart and sinks, the faith of these people has ceased to function properly. They do not believe in Jesus any longer. If your readers would not be familiar with shipwrecks, you could consider using a comparable metaphor or stating the meaning plainly. See the notes on this verse for translation options. (See: [[rc://*/ta/man/translate/figs-metaphor]])\n\n## Other Possible Translation Difficulties in This Chapter\n\n### The list in [1:9–10](../01/09.md)\n\nIn these verses, Paul provides a list of some of the kinds of people for whom the law was given. Paul gives four pairs of words connected with “and,” six individual words, and then a concluding phrase. You may need to break this long list into multiple different sentences, as the UST does. If you do, you could still preserve the general structure of Paul’s list, as the UST does in most places. Consider how you would include a list of this kind in your language.'
 
 function App() {
+  const markdownHtml = markdownToHTML(MARKDOWN)
+
   return (
     <>
-      <AddTsvRowSandbox />
+      <h1>HTML Content:</h1>
+      <div dangerouslySetInnerHTML={{ __html: markdownHtml }} />
     </>
   )
 }

--- a/src/core/markdownToHTML.ts
+++ b/src/core/markdownToHTML.ts
@@ -1,0 +1,15 @@
+import DOMPurify from 'dompurify'
+import { marked } from 'marked'
+
+/**
+ * A string containing markdown content
+ */
+type MarkdownString = string
+
+/**
+ * A string representing HTML content
+ */
+type HTMLString = string
+
+export const markdownToHTML = (markdown: MarkdownString) =>
+  DOMPurify.sanitize(marked.parse(markdown) as HTMLString)


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- [ ] Add simple markdown to html helper function (this will be used in the translation note vscode extension)

#### Please include detailed Test instructions for your pull request:
- [x] Launch the vite sandbox. The code for this sandbox is in **App.tsx**
    `pnpm install && pnpm dev`
- [x] Verify that content displayed in the sandbox is html and not raw markdown content. 

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
